### PR TITLE
gpt api 연결 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+
+# env
+.env

--- a/lib/NLP/env/env.dart
+++ b/lib/NLP/env/env.dart
@@ -1,0 +1,8 @@
+import 'package:envied/envied.dart';
+part 'env.g.dart';
+
+@Envied(path: ".env")
+abstract class Env {
+  @EnviedField(varName: 'OPEN_AI_API_KEY') // the .env variable.
+  static const apiKey = _Env.apiKey;
+}

--- a/lib/NLP/gpt3_api.dart
+++ b/lib/NLP/gpt3_api.dart
@@ -1,0 +1,41 @@
+import 'package:dart_openai/openai.dart';
+import 'env/env.dart';
+import 'dart:convert';
+
+//str에 스트링 넣으면 감정 분석 스트링 리턴
+Future<String> getEmotionFromGpt3(String str) async {
+  OpenAI.apiKey = Env.apiKey;
+  str = str + "\\n\\n###\\n\\n {'emotion':";
+
+  final completion = await OpenAI.instance.completion.create(
+      model: "ada:ft-personal-2023-04-05-16-31-41",
+      prompt: str,
+      //"There was a sad fish in blue sky. It was sunny.\\n\\n###\\n\\n {'emotion':"
+      temperature: 0.7,
+      maxTokens: 256,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+      stop: "###");
+
+  return "{'emotion':" + completion.choices[0].text;
+}
+
+String testtext2 = //테스트용 예시 api 호출시 출력 텍스트
+    "{'emotion':{'admiration': 0, 'amusement': 0, 'anger': 0, 'annoyance': 0, 'approval': 0, 'caring': 0, 'confusion': 0, 'curiosity': 0, 'desire': 0, 'disappointment': 0, 'disapproval': 0, 'disgust': 0, 'embarrassment': 0, 'excitement': 0, 'fear': 0, 'gratitude': 0, 'grief': 1, 'joy': 0, 'love': 0, 'nervousness': 0, 'optimism': 0, 'pride': 0, 'realization': 0, 'relief': 0, 'remorse': 0, 'sadness': 1, 'surprise': 0, 'neutral': 0}, 'weather': 'sunny', 'hue': [blue], 'saturation': None, 'value': 'high'}";
+
+Map<String, dynamic> gpt3StrToMap(String str) {
+  str = str.replaceAll("'", '"');
+  str = str.replaceAll('None', 'null');
+  List<String> str_list = str.split(RegExp(r'[\[\]]'));
+
+  String result_str = str_list[0] +
+      '["' +
+      str_list[1].replaceAll(',', '","') +
+      '"]' +
+      str_list[2];
+  //print("result_str: " + result_str);
+
+  Map<String, dynamic> jsonMap = jsonDecode(result_str);
+  return jsonMap;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.4 <3.0.0'
+  sdk: ">=2.18.4 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -32,7 +32,6 @@ dependencies:
   collection:
   flutter:
     sdk: flutter
-
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -47,6 +46,8 @@ dependencies:
   path_provider: ^2.0.14
   shared_preferences: ^2.0.20
 
+  dart_openai: ^1.9.1
+  envied: ^0.3.0
 
 dev_dependencies:
   flutter_test:
@@ -59,15 +60,14 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
   flutter_native_splash: ^2.2.0+1
-
-
+  build_runner:
+  envied_generator: ^0.3.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
gpt api 연결 추가
getEmotionFromGpt3 : GPT-3 API를 사용하여 텍스트의 감정을 분석하는 함수 
gpt3StrToMap : GPT-3 API의 JSON 응답을 파싱하여 Map 객체로 변환하는 함수

api 키를 위한 env 추가
gitignore에 .env 추가

관련 패키지 pubspec yaml에 추가